### PR TITLE
Simplify contribution delta tooltip with dynamic same-date-last-year label

### DIFF
--- a/assets/js/site.js
+++ b/assets/js/site.js
@@ -300,8 +300,11 @@
           var up = pct >= 0;
           deltaEl.textContent = (up ? '▲ +' : '▼ ') + pct + '%';
           deltaEl.classList.add(up ? 'is-up' : 'is-down');
-          deltaEl.title = 'Compared with ' + prevTotal + ' over the same period in ' + prevYear +
-                          ' (Jan 1 to today)';
+          var prevCutoffLabel = new Date(prevCutoff + 'T00:00:00').toLocaleDateString(undefined, {
+            month: 'short', day: 'numeric', year: 'numeric'
+          });
+          deltaEl.title = 'Compared with ' + prevTotal + ' contributions on the same date last year (' +
+                          prevCutoffLabel + ')';
           deltaEl.hidden = false;
         }
       }


### PR DESCRIPTION
## Summary
- Replace the vague "Compared with 25 over the same period in 2025 (Jan 1 to today)" tooltip with a clearer, fully dynamic label: "Compared with 25 contributions on the same date last year (Aug 1, 2025)".
- Previous year and previous total were already computed dynamically; this just formats the cutoff date into a readable label instead of the confusing "Jan 1 to today" phrasing.

## Test plan
- [x] Verified locally that the delta tooltip renders the correct dynamic date and count for the current year vs. last year.